### PR TITLE
Translate dashboard and table pagination to English

### DIFF
--- a/src/components/third-party/react-table/TablePagination.tsx
+++ b/src/components/third-party/react-table/TablePagination.tsx
@@ -62,7 +62,7 @@ export default function TablePagination({ getPageCount, setPageIndex, setPageSiz
         <Stack direction="row" sx={{ gap: 1, alignItems: 'center' }}>
           <Stack direction="row" sx={{ gap: 1, alignItems: 'center' }}>
             <Typography variant="caption" color="secondary">
-              Số dòng mỗi trang
+              Rows per page
             </Typography>
             <FormControl>
               <Select
@@ -84,7 +84,7 @@ export default function TablePagination({ getPageCount, setPageIndex, setPageSiz
             </FormControl>
           </Stack>
           <Typography variant="caption" color="secondary">
-            Chuyển tới
+            Go to
           </Typography>
           <TextField
             size="small"
@@ -94,6 +94,7 @@ export default function TablePagination({ getPageCount, setPageIndex, setPageSiz
               const page = e.target.value ? Number(e.target.value) - 1 : 0;
               setPageIndex(page);
             }}
+            inputProps={{ 'aria-label': 'Go to page' }}
             sx={{ '& .MuiOutlinedInput-input': { py: 0.75, px: 1.25, width: 36 } }}
           />
         </Stack>

--- a/src/pages/dashboard/default.tsx
+++ b/src/pages/dashboard/default.tsx
@@ -36,19 +36,19 @@ export default function DashboardDefault() {
     <Grid container rowSpacing={4.5} columnSpacing={2.75}>
       {/* row 1 */}
       <Grid sx={{ mb: -2.25 }} size={12}>
-        <Typography variant="h5">Thống kê tất cả Job Number</Typography>
+        <Typography variant="h5">Job Number Overview</Typography>
       </Grid>
       <Grid size={{ xs: 12, lg: 3, sm: 6 }}>
-        <ReportCard primary={totalJobNumber?.total || 0} secondary="Tổng số các Job Number" color="primary.light" iconPrimary={BarChartOutlined} />
+        <ReportCard primary={totalJobNumber?.total || 0} secondary="Total Job Numbers" color="primary.light" iconPrimary={BarChartOutlined} />
       </Grid>
       <Grid size={{ xs: 12, lg: 3, sm: 6 }}>
-        <ReportCard primary={totalJobNumber?.new || 0} secondary="Mới" color="warning.main" iconPrimary={PlusSquareOutlined} />
+        <ReportCard primary={totalJobNumber?.new || 0} secondary="New" color="warning.main" iconPrimary={PlusSquareOutlined} />
       </Grid>
       <Grid size={{ xs: 12, lg: 3, sm: 6 }}>
-        <ReportCard primary={totalJobNumber?.crosschecked || 0} secondary="Đã Kiểm tra chéo" color="error.main" iconPrimary={FileTextOutlined} />
+        <ReportCard primary={totalJobNumber?.crosschecked || 0} secondary="Cross-checked" color="error.main" iconPrimary={FileTextOutlined} />
       </Grid>
       <Grid size={{ xs: 12, lg: 3, sm: 6 }}>
-        <ReportCard primary={totalJobNumber?.completed || 0} secondary="Đã Trích Xuất" color="success.main" iconPrimary={FileDoneOutlined} />
+        <ReportCard primary={totalJobNumber?.completed || 0} secondary="Extracted" color="success.main" iconPrimary={FileDoneOutlined} />
       </Grid>
 
       <Grid sx={{ display: { sm: 'none', md: 'block', lg: 'none' } }} size={{ md: 8 }} />
@@ -63,7 +63,7 @@ export default function DashboardDefault() {
       <Grid size={{ xs: 12, md: 12, lg: 12 }}>
         <Grid container alignItems="center" justifyContent="space-between">
           <Grid>
-            <Typography variant="h5">Job Number gần đây</Typography>
+            <Typography variant="h5">Recent Job Numbers</Typography>
           </Grid>
           <Grid />
         </Grid>

--- a/src/sections/apps/invoice/JobNumberPieChart.tsx
+++ b/src/sections/apps/invoice/JobNumberPieChart.tsx
@@ -9,7 +9,7 @@ import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
 import MainCard from 'components/MainCard';
 import Dot from 'components/@extended/Dot';
 import { FormControl, MenuItem, Select, Stack } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { APIResponse } from 'types/response';
 import { getCurrentJobNumberByStatus } from 'api/dashboard';
 import { InputLabel } from '@mui/material';
@@ -19,10 +19,16 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TaxCodeAutocomplete from 'components/common/TaxCodeAutocomplete';
 import { getClientDetail } from 'api/client';
 import { ClientType } from 'types/pages/client';
+
+const STATUS_ORDER = ['new', 'ready', 'crosschecked', 'completed'] as const;
+type KnownStatusKey = typeof STATUS_ORDER[number];
+type StatusKey = KnownStatusKey | 'unknown';
+type NormalizedDatum = { key: StatusKey; value: number; label: string; color: string };
 // ==============================|| INVOICE - PIE CHART ||============================== //
 
 export default function JobNumberPieChart() {
   const theme = useTheme();
+  const statusOrder = STATUS_ORDER;
   const [totalJobNumber, setTotalJobNumber] = useState<any>(null);
   const [selectedUser, setSelectedUser] = useState<UserType | null>(null);
   const [userList, setUserList] = useState<UserType[]>();
@@ -79,31 +85,89 @@ export default function JobNumberPieChart() {
     setSelectedUser(event.target.value);
   }
 
-  const chartData = (Array.isArray(totalJobNumber) ? totalJobNumber : []).map((item: any) => {
-    let color;
-    switch (item.label) {
-      case 'Mới':
-        color = theme.palette.warning.main;
-        break;
-      case 'Sẵn sàng':
-        color = theme.palette.primary.main;
-        break;
-      case 'Đã kiểm tra chéo':
-        color = theme.palette.error.main;
-        break;
-      case 'Đã trích xuất':
-        color = theme.palette.success.main;
-        break;
+  const statusConfig: Record<StatusKey, { label: string; color: string }> = useMemo(
+    () => ({
+      new: { label: 'New', color: theme.palette.warning.main },
+      ready: { label: 'Ready', color: theme.palette.primary.main },
+      crosschecked: { label: 'Cross-checked', color: theme.palette.error.main },
+      completed: { label: 'Extracted', color: theme.palette.success.main },
+      unknown: { label: 'Unknown', color: theme.palette.grey[500] }
+    }),
+    [theme.palette.error.main, theme.palette.grey[500], theme.palette.primary.main, theme.palette.success.main, theme.palette.warning.main]
+  );
+
+  const normalizeStatusKey = (value?: string): KnownStatusKey | '' => {
+    if (!value) return '';
+
+    const sanitized = value
+      .toString()
+      .trim()
+      .normalize('NFD')
+      .replace(/[^\p{L}]/gu, '')
+      .toLowerCase();
+
+    switch (sanitized) {
+      case 'moi':
+      case 'new':
+        return 'new';
+      case 'sansang':
+      case 'ready':
+        return 'ready';
+      case 'dakiemtracheo':
+      case 'dackiemtracheo':
+      case 'crosschecked':
+        return 'crosschecked';
+      case 'datrichxuat':
+      case 'daextract':
+      case 'extract':
+      case 'extracted':
+      case 'completed':
+        return 'completed';
       default:
-        color = theme.palette.grey[500]; // fallback
+        return '';
     }
-    return { ...item, color };
-  });
+  };
+
+  const normalizedData = useMemo<NormalizedDatum[]>(() => {
+    const rawData = Array.isArray(totalJobNumber) ? totalJobNumber : [];
+
+    return rawData.map((item: any) => {
+      const candidates = [item?.key, item?.status, item?.label];
+      const normalizedKey = candidates
+        .map((candidate) => normalizeStatusKey(candidate))
+        .find((candidate): candidate is KnownStatusKey => Boolean(candidate));
+      const statusKey: StatusKey = normalizedKey ?? 'unknown';
+      const config = statusConfig[statusKey];
+      const numericValue = typeof item?.value === 'number' ? item.value : Number(item?.value) || 0;
+
+      return {
+        key: statusKey,
+        value: numericValue,
+        label: config.label,
+        color: config.color
+      };
+    });
+  }, [statusConfig, totalJobNumber]);
+
+  const chartData: NormalizedDatum[] = [
+    ...statusOrder.map((statusKey) => {
+      const matched = normalizedData.find((item) => item.key === statusKey);
+      const config = statusConfig[statusKey];
+
+      return {
+        key: statusKey,
+        value: matched?.value ?? 0,
+        label: config.label,
+        color: config.color
+      };
+    }),
+    ...normalizedData.filter((item) => !statusOrder.some((status) => status === item.key))
+  ];
 
   //sx style
   const DotSize = { display: 'flex', alignItems: 'center', gap: 1 };
   const ExpenseSize = { fontSize: '1rem', lineHeight: '1.5rem', fontWeight: 500 };
-  const total = (Array.isArray(chartData) ? chartData : []).reduce((acc: number, cur: any) => {
+  const total = chartData.reduce((acc: number, cur) => {
     const v = typeof cur?.value === 'number' ? cur.value : 0;
     return acc + v;
   }, 0);
@@ -114,19 +178,19 @@ export default function JobNumberPieChart() {
         <Grid container alignItems="center" spacing={1}>
           <Stack sx={{ alignItems: { xs: 'center', sm: 'flex-start' } }}>
             <Stack direction="row" sx={{ alignItems: 'center' }}>
-              <Typography variant='h5'>Job Number theo người dùng</Typography>
+              <Typography variant="h5">Job Numbers by User</Typography>
             </Stack>
           </Stack>
           <FormControl fullWidth sx={{ marginY: 3 }}>
-            <InputLabel id="user-select">Chọn User</InputLabel>
+            <InputLabel id="user-select">Select User</InputLabel>
             <Select
               labelId="user-select"
               id="user-select"
               value={selectedUser ?? "all"}
               onChange={handleChange}
-              label="Chọn User"
+              label="Select User"
             >
-              <MenuItem value="all">Tất cả</MenuItem>
+              <MenuItem value="all">All</MenuItem>
               {(userList ?? []).map((user: UserType) => (
                 <MenuItem key={user.id} value={user.id}>
                   {user.full_name}
@@ -138,7 +202,7 @@ export default function JobNumberPieChart() {
           <DatePicker
             format="dd/MM/yyyy"
             value={selectedDate}
-            label="Chọn Ngày/Tháng/Năm"
+            label="Select Date"
             onChange={handleDateChange}
             slotProps={{
               textField: {
@@ -161,8 +225,7 @@ export default function JobNumberPieChart() {
               margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
               series={[
                 {
-                  data: (chartData ?? []).map((d: any) => ({
-                    // đảm bảo mỗi item luôn có value/label/color hợp lệ
+                  data: chartData.map((d) => ({
                     value: typeof d?.value === 'number' ? d.value : 0,
                     label: d?.label ?? '',
                     color: d?.color ?? '#9e9e9e'
@@ -195,10 +258,10 @@ export default function JobNumberPieChart() {
               <Grid sx={DotSize} size="grow">
                 <Dot color="warning" size={12} />
                 <Typography variant="subtitle1" color="text.secondary">
-                  Mới
+                  New
                 </Typography>
               </Grid>
-              <Grid sx={ExpenseSize}>{chartData?.[0]?.value ?? 0}</Grid>
+              <Grid sx={ExpenseSize}>{chartData.find((item) => item.key === 'new')?.value ?? 0}</Grid>
             </Grid>
           </Grid>
           <Grid size={12}>
@@ -207,10 +270,10 @@ export default function JobNumberPieChart() {
               <Grid sx={DotSize} size="grow">
                 <Dot color="primary" size={12} />
                 <Typography variant="subtitle1" color="text.secondary">
-                  Sẵn sàng
+                  Ready
                 </Typography>
               </Grid>
-              <Grid sx={ExpenseSize}>{chartData?.[1]?.value ?? 0}</Grid>
+              <Grid sx={ExpenseSize}>{chartData.find((item) => item.key === 'ready')?.value ?? 0}</Grid>
             </Grid>
           </Grid>
           <Grid size={12}>
@@ -219,10 +282,10 @@ export default function JobNumberPieChart() {
               <Grid sx={DotSize} size="grow">
                 <Dot color="error" size={12} />
                 <Typography variant="subtitle1" color="text.secondary">
-                  Đã kiểm tra chéo
+                  Cross-checked
                 </Typography>
               </Grid>
-              <Grid sx={ExpenseSize}>{chartData?.[2]?.value ?? 0}</Grid>
+              <Grid sx={ExpenseSize}>{chartData.find((item) => item.key === 'crosschecked')?.value ?? 0}</Grid>
             </Grid>
           </Grid>
           <Grid size={12}>
@@ -231,10 +294,10 @@ export default function JobNumberPieChart() {
               <Grid sx={DotSize} size="grow">
                 <Dot color="success" size={12} />
                 <Typography variant="subtitle1" color="text.secondary">
-                  Đã trích xuất
+                  Extracted
                 </Typography>
               </Grid>
-              <Grid sx={ExpenseSize}>{chartData?.[3]?.value ?? 0}</Grid>
+              <Grid sx={ExpenseSize}>{chartData.find((item) => item.key === 'completed')?.value ?? 0}</Grid>
             </Grid>
           </Grid>
         </Grid>

--- a/src/sections/dashboard/analytics/JobOverviewCreateChart.tsx
+++ b/src/sections/dashboard/analytics/JobOverviewCreateChart.tsx
@@ -34,9 +34,9 @@ export default function JobOverviewCreateChart() {
             <Stack sx={{ alignItems: { xs: 'center', sm: 'flex-start' }, ml: { xs: 0, sm: 2 }, mt: 3 }}>
               <Stack direction="row" sx={{ gap: 0.5, alignItems: 'center' }}>
                 <Typography variant="h5">
-                  Thống kê Job Number{" "}
-                  {slot === "week" && `tuần ${getWeekOfMonth(currentDate)} `}
-                  tháng {currentDate.getMonth() + 1}
+                  Job Number Statistics{' '}
+                  {slot === 'week' && `Week ${getWeekOfMonth(currentDate)} `}
+                  Month {currentDate.getMonth() + 1}
                 </Typography>
               </Stack>
             </Stack>
@@ -48,10 +48,10 @@ export default function JobOverviewCreateChart() {
             >
               <ToggleButtonGroup exclusive onChange={handleChange} size="small" value={slot}>
                 <ToggleButton disabled={slot === 'week'} value="week" sx={{ px: 2, py: 0.5 }}>
-                  Tuần
+                  Week
                 </ToggleButton>
                 <ToggleButton disabled={slot === 'month'} value="month" sx={{ px: 2, py: 0.5 }}>
-                  Tháng
+                  Month
                 </ToggleButton>
               </ToggleButtonGroup>
               {/* <Select value={quantity} onChange={handleQuantity} size="small">

--- a/src/sections/dashboard/default/JobNumberBarChart.tsx
+++ b/src/sections/dashboard/default/JobNumberBarChart.tsx
@@ -45,7 +45,7 @@ export default function JobNumberBarChart({ slot }: JobNumberDateChartProps) {
     <BarChart
       hideLegend
       height={380}
-      series={[{ data, label: 'Số Job Number' }]}
+      series={[{ data, label: 'Job Numbers' }]}
       xAxis={[{ data: labels, scaleType: 'band', disableLine: true, disableTicks: true, tickLabelStyle: axisFonstyle }]}
       yAxis={[{ position: 'none' }]}
       slotProps={{ bar: { rx: 5, ry: 5 } }}

--- a/src/sections/dashboard/default/RecentJobNumberTable.tsx
+++ b/src/sections/dashboard/default/RecentJobNumberTable.tsx
@@ -74,10 +74,10 @@ interface HeadCell {
 }
 
 const headCells: readonly HeadCell[] = [
-  { id: 'name', align: 'left', disablePadding: false, label: 'Tên Job Number' },
-  { id: 'company_name', align: 'left', disablePadding: true, label: 'Công ty' },
-  { id: 'method', align: 'right', disablePadding: false, label: 'Tác nghiệp' },
-  { id: 'status', align: 'left', disablePadding: false, label: 'Trạng thái' }
+  { id: 'name', align: 'left', disablePadding: false, label: 'Job Number' },
+  { id: 'company_name', align: 'left', disablePadding: true, label: 'Company' },
+  { id: 'method', align: 'right', disablePadding: false, label: 'Operation' },
+  { id: 'status', align: 'left', disablePadding: false, label: 'Status' }
 ];
 
 interface RecentJobNumberTableProps {
@@ -113,23 +113,23 @@ function OrderStatus({ status }: { status: string }) {
   switch (status) {
     case 'new':
       color = 'warning';
-      title = 'Mới';
+      title = 'New';
       break;
     case 'completed':
       color = 'success';
-      title = 'Đã Extract';
+      title = 'Extracted';
       break;
     case 'crosschecked':
       color = 'error';
-      title = 'Đã Crosschecked';
+      title = 'Cross-checked';
       break;
     case 'ready':
       color = 'primary';
-      title = 'Sẵn sàng';
+      title = 'Ready';
       break;
     default:
       color = 'primary';
-      title = 'Không rõ';
+      title = 'Unknown';
   }
 
   return (
@@ -153,32 +153,32 @@ export default function OrderTable() {
   }, []);
 
   const fetchData = async () => {
-  const res: APIResponse = await getJobNumberRecent();
+    const res: APIResponse = await getJobNumberRecent();
 
-  if (res.status === 'success' && Array.isArray(res.data)) {
-    const sorted = res.data
-      .filter((item: Data) => item.projects?.[0]?.created_at) // bỏ những item không có project hoặc created_at
-      .sort((a: Data, b: Data) => {
-        const dateA = new Date(a.projects[0].created_at).getTime();
-        const dateB = new Date(b.projects[0].created_at).getTime();
-        return dateB - dateA; // mới nhất lên đầu
-      })
-      .slice(0, 6); // lấy 6 cái gần nhất
+    if (res.status === 'success' && Array.isArray(res.data)) {
+      const sorted = res.data
+        .filter((item: Data) => item.projects?.[0]?.created_at) // skip items without projects or creation date
+        .sort((a: Data, b: Data) => {
+          const dateA = new Date(a.projects[0].created_at).getTime();
+          const dateB = new Date(b.projects[0].created_at).getTime();
+          return dateB - dateA; // newest first
+        })
+        .slice(0, 6); // keep the 6 most recent records
 
-    setRecentJobNumber(sorted);
-  } else {
-    setRecentJobNumber([]);
-  }
-};
+      setRecentJobNumber(sorted);
+    } else {
+      setRecentJobNumber([]);
+    }
+  };
 
-  function getOperate(method : string) : string{
-    switch(method){
+  function getOperate(method: string): string {
+    switch (method) {
       case 'import':
-        return 'Nhập khẩu';
+        return 'Import';
       case 'export':
-        return 'Xuất khẩu';
+        return 'Export';
       default:
-        return 'Không xác định';
+        return 'Unknown';
     }
   }
 


### PR DESCRIPTION
## Summary
- translate dashboard metric cards, headers, and status labels to English
- normalize job number chart data to show English labels across the dashboard widgets
- update the shared table pagination control to use English copy and improve its accessibility

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d68ce5493c8325a67eb247ee99e43d