### PR TITLE
Translate default product settings and chart labels

### DIFF
--- a/src/pages/apps/default-setting/default-product/ExportProductDefault.tsx
+++ b/src/pages/apps/default-setting/default-product/ExportProductDefault.tsx
@@ -6,16 +6,23 @@ import { Box } from '@mui/material';
 import { defaultProductFormFieldsControlExport } from 'types/extract-form-field/default-product-form';
 import { Field, useFormikContext } from 'formik';
 import ContextMenu from 'pages/apps/job-number/form/dynamic-fields/ContextMenu';
+import { useIntl } from 'react-intl';
 
 
 const ExportProductDefault: React.FC = () => {
     const { setFieldValue } = useFormikContext();
+    const intl = useIntl();
 
     return (
         <Box>
             <Grid container spacing={3}>
                 <Grid>
-                    <Typography variant="h5">Cập nhật thông số mặc định sản phẩm</Typography>
+                    <Typography variant="h5">
+                        {intl.formatMessage({
+                            id: 'default-setting.product.update-default-parameters',
+                            defaultMessage: 'Update default product parameters'
+                        })}
+                    </Typography>
                 </Grid>
 
                 <Grid size={{ xs: 12, sm: 12, lg: 12 }}>
@@ -27,7 +34,10 @@ const ExportProductDefault: React.FC = () => {
                             export
                         </Box>
                         <Box component="span" sx={{ display: 'none' }}>
-                            Tùy chọn nhập mã hàng
+                            {intl.formatMessage({
+                                id: 'default-setting.product.item-code-option-label',
+                                defaultMessage: 'Item code entry option'
+                            })}
                         </Box>
                         <Stack sx={{ gap: 1 }}>
                             <FormGroup>
@@ -41,7 +51,10 @@ const ExportProductDefault: React.FC = () => {
                                                     onChange={() => setFieldValue('item_code_option', !field.value)}
                                                 />
                                             }
-                                            label="Tùy chọn nhập mã hàng"
+                                            label={intl.formatMessage({
+                                                id: 'default-setting.product.item-code-option-label',
+                                                defaultMessage: 'Item code entry option'
+                                            })}
                                         />
                                     )}
                                 </Field>
@@ -57,7 +70,12 @@ const ExportProductDefault: React.FC = () => {
                     />
 
                     <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                        <Typography variant="h5">Số lượng và đơn vị</Typography>
+                        <Typography variant="h5">
+                            {intl.formatMessage({
+                                id: 'default-setting.product.export.quantity-section',
+                                defaultMessage: 'Quantity and units'
+                            })}
+                        </Typography>
                     </Grid>
 
                     <DynamicField
@@ -67,7 +85,12 @@ const ExportProductDefault: React.FC = () => {
                     />
 
                     <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                        <Typography variant="h5">Đơn giá và tiền tệ</Typography>
+                        <Typography variant="h5">
+                            {intl.formatMessage({
+                                id: 'default-setting.product.export.unit-price-section',
+                                defaultMessage: 'Unit price and currency'
+                            })}
+                        </Typography>
                     </Grid>
 
                     <DynamicField
@@ -77,7 +100,12 @@ const ExportProductDefault: React.FC = () => {
                     />
 
                     <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                        <Typography variant="h5">Thuế xuất nhập khẩu</Typography>
+                        <Typography variant="h5">
+                            {intl.formatMessage({
+                                id: 'default-setting.product.export.tax-section',
+                                defaultMessage: 'Export/import taxes'
+                            })}
+                        </Typography>
                     </Grid>
 
                     <DynamicField
@@ -87,7 +115,12 @@ const ExportProductDefault: React.FC = () => {
                     />
 
                     <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                        <Typography variant="h5">Tờ khai tạm nhập/tái xuất</Typography>
+                        <Typography variant="h5">
+                            {intl.formatMessage({
+                                id: 'default-setting.product.export.temporary-declaration-section',
+                                defaultMessage: 'Temporary import/export declaration'
+                            })}
+                        </Typography>
                     </Grid>
                     <DynamicField
                         fields={defaultProductFormFieldsControlExport.slice(21, 24)}
@@ -96,7 +129,12 @@ const ExportProductDefault: React.FC = () => {
                     />
 
                     <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                        <Typography variant="h5">Pháp lý liên quan</Typography>
+                        <Typography variant="h5">
+                            {intl.formatMessage({
+                                id: 'default-setting.product.export.legal-section',
+                                defaultMessage: 'Related legal documents'
+                            })}
+                        </Typography>
                     </Grid>
 
                     <DynamicField
@@ -107,7 +145,12 @@ const ExportProductDefault: React.FC = () => {
 
 
                     <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                        <Typography variant="h5">Thông tin bổ sung</Typography>
+                        <Typography variant="h5">
+                            {intl.formatMessage({
+                                id: 'default-setting.product.export.additional-info-section',
+                                defaultMessage: 'Additional information'
+                            })}
+                        </Typography>
                     </Grid>
                     <DynamicField
                         fields={defaultProductFormFieldsControlExport.slice(29, 31)}

--- a/src/pages/apps/default-setting/default-product/ImportProductDefault.tsx
+++ b/src/pages/apps/default-setting/default-product/ImportProductDefault.tsx
@@ -7,16 +7,23 @@ import { defaultProductFormFieldsControlImport } from 'types/extract-form-field/
 import { Field, useFormikContext } from 'formik';
 import { Checkbox } from '@mui/material';
 import ContextMenu from 'pages/apps/job-number/form/dynamic-fields/ContextMenu';
+import { useIntl } from 'react-intl';
 
 
 const ImportProductDefault: React.FC = () => {
     const { setFieldValue } = useFormikContext();
+    const intl = useIntl();
 
     return (
         <Box>
             <Grid container spacing={3}>
                 <Grid>
-                    <Typography variant="h5">Cập nhật thông số mặc định sản phẩm</Typography>
+                    <Typography variant="h5">
+                        {intl.formatMessage({
+                            id: 'default-setting.product.update-default-parameters',
+                            defaultMessage: 'Update default product parameters'
+                        })}
+                    </Typography>
                 </Grid>
 
 
@@ -29,7 +36,10 @@ const ImportProductDefault: React.FC = () => {
                             import
                         </Box>
                         <Box component="span" sx={{ display: 'none' }}>
-                            Tùy chọn nhập mã hàng
+                            {intl.formatMessage({
+                                id: 'default-setting.product.item-code-option-label',
+                                defaultMessage: 'Item code entry option'
+                            })}
                         </Box>
                         <Stack sx={{ gap: 1 }}>
                             <FormGroup>
@@ -43,7 +53,10 @@ const ImportProductDefault: React.FC = () => {
                                                     onChange={() => setFieldValue('item_code_option', !field.value)}
                                                 />
                                             }
-                                            label="Tùy chọn nhập mã hàng"
+                                            label={intl.formatMessage({
+                                                id: 'default-setting.product.item-code-option-label',
+                                                defaultMessage: 'Item code entry option'
+                                            })}
                                         />
                                     )}
                                 </Field>
@@ -66,7 +79,12 @@ const ImportProductDefault: React.FC = () => {
                 />
 
                 <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                    <Typography variant="h5">Số lượng & Đơn giá</Typography>
+                    <Typography variant="h5">
+                        {intl.formatMessage({
+                            id: 'default-setting.product.import.quantity-price-section',
+                            defaultMessage: 'Quantity & unit price'
+                        })}
+                    </Typography>
                 </Grid>
 
                 <DynamicField
@@ -76,7 +94,12 @@ const ImportProductDefault: React.FC = () => {
                 />
 
                 <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                    <Typography variant="h5">Thuế nhập khẩu</Typography>
+                    <Typography variant="h5">
+                        {intl.formatMessage({
+                            id: 'default-setting.product.import.import-tax-section',
+                            defaultMessage: 'Import taxes'
+                        })}
+                    </Typography>
                 </Grid>
 
                 <DynamicField
@@ -86,7 +109,12 @@ const ImportProductDefault: React.FC = () => {
                 />
 
                 <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                    <Typography variant="h5">Thuế khác và miễn giảm</Typography>
+                    <Typography variant="h5">
+                        {intl.formatMessage({
+                            id: 'default-setting.product.import.other-tax-section',
+                            defaultMessage: 'Other taxes & exemptions'
+                        })}
+                    </Typography>
                 </Grid>
 
                 <DynamicField
@@ -122,7 +150,12 @@ const ImportProductDefault: React.FC = () => {
                 />
                 <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}></Grid>
                 <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                    <Typography variant="h5">Thuế tuyệt đối & hạn ngạch</Typography>
+                    <Typography variant="h5">
+                        {intl.formatMessage({
+                            id: 'default-setting.product.import.absolute-tax-section',
+                            defaultMessage: 'Absolute tax & quota'
+                        })}
+                    </Typography>
                 </Grid>
 
                 <DynamicField
@@ -132,7 +165,12 @@ const ImportProductDefault: React.FC = () => {
                 />
 
                 <Grid size={{ xs: 12 }} sx={{ marginY: 3 }}>
-                    <Typography variant="h5">Điều chỉnh & tạm nhập tái xuất</Typography>
+                    <Typography variant="h5">
+                        {intl.formatMessage({
+                            id: 'default-setting.product.import.adjustment-section',
+                            defaultMessage: 'Adjustments & temporary import/export'
+                        })}
+                    </Typography>
                 </Grid>
 
                 <DynamicField

--- a/src/pages/apps/job-number/form/dynamic-fields/GuideAIForm.tsx
+++ b/src/pages/apps/job-number/form/dynamic-fields/GuideAIForm.tsx
@@ -12,6 +12,7 @@ import { Formik } from 'formik';
 import * as Yup from 'yup';
 import { getClientGuidingAI, updateClientGuidingAI } from 'api/client';
 import { useDefaultSetting } from 'pages/apps/default-setting/MainPage';
+import { useIntl } from 'react-intl';
 
 type Props = {
     label: string;
@@ -19,15 +20,39 @@ type Props = {
     method: string;
 };
 
-const validationSchema = Yup.object({
-    guide_text: Yup.string().trim().required('Vui lòng nhập hướng dẫn'),
-    customs_procedure_type: Yup.number().required('Thiếu trường loại hình kinh doanh'),
-    field: Yup.string().trim().required('Thiếu trường field'),
-});
-
 export default function GuideAIForm({ label, fieldKey, method }: Props) {
 
     const { client, customsProcedureType } = useDefaultSetting();
+    const intl = useIntl();
+
+    const validationSchema = React.useMemo(
+        () =>
+            Yup.object({
+                guide_text: Yup.string()
+                    .trim()
+                    .required(
+                        intl.formatMessage({
+                            id: 'guide-ai.validation.guide-text.required',
+                            defaultMessage: 'Please enter the guidance'
+                        })
+                    ),
+                customs_procedure_type: Yup.number().required(
+                    intl.formatMessage({
+                        id: 'guide-ai.validation.customs-procedure.required',
+                        defaultMessage: 'Customs procedure type is required'
+                    })
+                ),
+                field: Yup.string()
+                    .trim()
+                    .required(
+                        intl.formatMessage({
+                            id: 'guide-ai.validation.field.required',
+                            defaultMessage: 'Field key is required'
+                        })
+                    )
+            }),
+        [intl]
+    );
 
     const [response, setResponse] = React.useState<any>();
 
@@ -54,7 +79,15 @@ export default function GuideAIForm({ label, fieldKey, method }: Props) {
 
                 }
             } catch (e: any) {
-                if (isMounted) setFetchError(e.response?.data?.message || e.message || 'Không thể tải dữ liệu');
+                if (isMounted)
+                    setFetchError(
+                        e.response?.data?.message ||
+                            e.message ||
+                            intl.formatMessage({
+                                id: 'guide-ai.error.unable-to-load',
+                                defaultMessage: 'Unable to load data'
+                            })
+                    );
             } finally {
                 if (isMounted) setLoading(false);
             }
@@ -64,13 +97,15 @@ export default function GuideAIForm({ label, fieldKey, method }: Props) {
         return () => {
             isMounted = false;
         };
-    }, [client.id, fieldKey, method]);
+    }, [client.id, fieldKey, intl, method]);
 
     if (loading) {
         return (
             <Box sx={{ padding: 3, textAlign: 'center' }}>
                 <CircularProgress />
-                <Typography sx={{ mt: 1 }}>Đang tải dữ liệu...</Typography>
+                <Typography sx={{ mt: 1 }}>
+                    {intl.formatMessage({ id: 'guide-ai.loading', defaultMessage: 'Loading data...' })}
+                </Typography>
             </Box>
         );
     }
@@ -118,10 +153,21 @@ export default function GuideAIForm({ label, fieldKey, method }: Props) {
                     }}
                 >
                     <Typography variant="h4" sx={{ opacity: 0.9, mt: 2, mb: 3 }}>
-                        Cập nhật hướng dẫn trích xuất thông tin AI
+                        {intl.formatMessage({
+                            id: 'guide-ai.form.title',
+                            defaultMessage: 'Update AI extraction guidelines'
+                        })}
                     </Typography>
 
-                    <InputLabel required>Hướng dẫn trích xuất trường {label}</InputLabel>
+                    <InputLabel required>
+                        {intl.formatMessage(
+                            {
+                                id: 'guide-ai.form.field-label',
+                                defaultMessage: 'Extraction guidance for {label}'
+                            },
+                            { label }
+                        )}
+                    </InputLabel>
 
                     <TextField
                         id="guide-ai"
@@ -141,7 +187,14 @@ export default function GuideAIForm({ label, fieldKey, method }: Props) {
 
                     <Box sx={{ display: 'flex', gap: 1, mt: 1 }}>
                         <Button type="submit" variant="contained" disabled={isSubmitting}>
-                            {isSubmitting ? <CircularProgress size={20} /> : 'Lưu hướng dẫn'}
+                            {isSubmitting ? (
+                                <CircularProgress size={20} />
+                            ) : (
+                                intl.formatMessage({
+                                    id: 'guide-ai.form.save',
+                                    defaultMessage: 'Save guidelines'
+                                })
+                            )}
                         </Button>
                     </Box>
                 </Box>

--- a/src/pages/apps/job-number/form/dynamic-fields/fieldLabels.ts
+++ b/src/pages/apps/job-number/form/dynamic-fields/fieldLabels.ts
@@ -577,6 +577,10 @@ const directFieldMessages: Record<string, MessageConfig> = {
         id: 'job-number.extract.import.form.product.taxable-value-currency-code',
         defaultMessage: 'Taxable value currency code',
     },
+    export_import_ratio: {
+        id: 'job-number.extract.export.form.product.export-import-ratio',
+        defaultMessage: 'Export/import ratio (%)',
+    },
     export_import_tax_amount: {
         id: 'job-number.extract.export.form.product.export-import-tax-amount',
         defaultMessage: 'Export/import tax amount',
@@ -873,6 +877,14 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
+        regex: /^product_info\.legal_document_code_(\d+)$/,
+        getMessage: (match) => ({
+            id: 'job-number.extract.export.form.product.legal-document-code',
+            defaultMessage: 'Legal document code ({index})',
+            values: { index: Number(match[1]) },
+        }),
+    },
+    {
         regex: /^container_info\.loading_location_code_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.export.form.container.loading-location-code',
@@ -889,7 +901,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^special_consumption_tax_code_(\d+)$/,
+        regex: /^(?:product_info\.)?special_consumption_tax_code_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.special-consumption-tax-code',
             defaultMessage: 'Special consumption tax schedule code ({index})',
@@ -897,7 +909,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^special_consumption_tax_exemption_reduction_code_(\d+)$/,
+        regex: /^(?:product_info\.)?special_consumption_tax_exemption_reduction_code_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.special-consumption-tax-exemption-code',
             defaultMessage: 'Special consumption tax exemption/reduction code ({index})',
@@ -905,7 +917,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^special_consumption_tax_reduction_amount_(\d+)$/,
+        regex: /^(?:product_info\.)?special_consumption_tax_reduction_amount_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.special-consumption-tax-reduction-amount',
             defaultMessage: 'Special consumption tax reduction amount ({index})',
@@ -913,7 +925,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^environmental_tax_code_(\d+)$/,
+        regex: /^(?:product_info\.)?environmental_tax_code_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.environmental-tax-code',
             defaultMessage: 'Environmental tax schedule code ({index})',
@@ -921,7 +933,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^environmental_tax_exemption_reduction_code_(\d+)$/,
+        regex: /^(?:product_info\.)?environmental_tax_exemption_reduction_code_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.environmental-tax-exemption-code',
             defaultMessage: 'Environmental tax exemption/reduction code ({index})',
@@ -929,7 +941,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^environmental_tax_reduction_amount_(\d+)$/,
+        regex: /^(?:product_info\.)?environmental_tax_reduction_amount_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.environmental-tax-reduction-amount',
             defaultMessage: 'Environmental tax reduction amount ({index})',
@@ -937,7 +949,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^vat_tax_code_(\d+)$/,
+        regex: /^(?:product_info\.)?vat_tax_code_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.vat-tax-code',
             defaultMessage: 'VAT schedule code ({index})',
@@ -945,7 +957,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^vat_tax_exemption_reduction_code_(\d+)$/,
+        regex: /^(?:product_info\.)?vat_tax_exemption_reduction_code_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.vat-tax-exemption-code',
             defaultMessage: 'VAT exemption/reduction code ({index})',
@@ -953,7 +965,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^vat_tax_reduction_amount_(\d+)$/,
+        regex: /^(?:product_info\.)?vat_tax_reduction_amount_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.vat-tax-reduction-amount',
             defaultMessage: 'VAT reduction amount ({index})',
@@ -961,7 +973,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^tax_rate_code_(\d+)$/,
+        regex: /^(?:product_info\.)?tax_rate_code_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.tax-rate-code',
             defaultMessage: 'Tax rate/matrix code ({index})',
@@ -969,7 +981,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^tax_exemption_reduction_code_(\d+)$/,
+        regex: /^(?:product_info\.)?tax_exemption_reduction_code_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.tax-exemption-code',
             defaultMessage: 'Tax exemption/reduction code ({index})',
@@ -977,7 +989,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^tax_reduction_amount_(\d+)$/,
+        regex: /^(?:product_info\.)?tax_reduction_amount_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.tax-reduction-amount',
             defaultMessage: 'Tax reduction amount ({index})',
@@ -985,7 +997,7 @@ const patternFieldMessages: { regex: RegExp; getMessage: (match: RegExpMatchArra
         }),
     },
     {
-        regex: /^adjustment_item_sequence_(\d+)$/,
+        regex: /^(?:product_info\.)?adjustment_item_sequence_(\d+)$/,
         getMessage: (match) => ({
             id: 'job-number.extract.import.form.product.adjustment-item-sequence',
             defaultMessage: 'Adjustment item sequence ({index})',
@@ -999,13 +1011,17 @@ export const formatFieldLabel = (field: FieldLike, intl: IntlShape): string => {
         return field.label;
     }
 
-    const direct = directFieldMessages[field.key];
+    const normalizedKey = field.key.startsWith('product_info.')
+        ? field.key.replace('product_info.', '')
+        : field.key;
+
+    const direct = directFieldMessages[normalizedKey];
     if (direct) {
         return intl.formatMessage({ id: direct.id, defaultMessage: direct.defaultMessage }, direct.values);
     }
 
     for (const pattern of patternFieldMessages) {
-        const match = field.key.match(pattern.regex);
+        const match = normalizedKey.match(pattern.regex);
         if (match) {
             const descriptor = pattern.getMessage(match);
             return intl.formatMessage({ id: descriptor.id, defaultMessage: descriptor.defaultMessage }, descriptor.values);

--- a/src/sections/dashboard/default/JobNumberBarChart.tsx
+++ b/src/sections/dashboard/default/JobNumberBarChart.tsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 
 import { BarChart } from '@mui/x-charts/BarChart';
 import { getJobNumberByDate } from 'api/dashboard';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { APIResponse } from 'types/response';
 
 interface JobNumberDateChartProps {
@@ -20,6 +20,79 @@ export default function JobNumberBarChart({ slot }: JobNumberDateChartProps) {
 
   const [data, setData] = useState<number[]>([]);
   const [labels, setLabels] = useState<string[]>([]);
+
+  const normalizeLabel = (label: string) =>
+    label
+      .normalize('NFC')
+      .replace(/,/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase();
+
+  const weekLabelMessages = useMemo(
+    () => ({
+      [normalizeLabel('Thứ Bảy')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.week.saturday',
+        defaultMessage: 'Saturday'
+      }),
+      [normalizeLabel('Chủ Nhật')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.week.sunday',
+        defaultMessage: 'Sunday'
+      }),
+      [normalizeLabel('Thứ Hai')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.week.monday',
+        defaultMessage: 'Monday'
+      }),
+      [normalizeLabel('Thứ Ba')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.week.tuesday',
+        defaultMessage: 'Tuesday'
+      }),
+      [normalizeLabel('Thứ Tư')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.week.wednesday',
+        defaultMessage: 'Wednesday'
+      }),
+      [normalizeLabel('Thứ Năm')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.week.thursday',
+        defaultMessage: 'Thursday'
+      }),
+      [normalizeLabel('Thứ Sáu')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.week.friday',
+        defaultMessage: 'Friday'
+      })
+    }),
+    [intl]
+  );
+
+  const monthLabelMessages = useMemo(
+    () => ({
+      [normalizeLabel('Tuần 1')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.month.week-1',
+        defaultMessage: 'Week 1'
+      }),
+      [normalizeLabel('Tuần 2')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.month.week-2',
+        defaultMessage: 'Week 2'
+      }),
+      [normalizeLabel('Tuần 3')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.month.week-3',
+        defaultMessage: 'Week 3'
+      }),
+      [normalizeLabel('Tuần 4')]: intl.formatMessage({
+        id: 'dashboard.charts.job-number-bar.month.week-4',
+        defaultMessage: 'Week 4'
+      })
+    }),
+    [intl]
+  );
+
+  const displayLabels = useMemo(() => {
+    const messageMap = slot === 'week' ? weekLabelMessages : monthLabelMessages;
+
+    return labels.map((label) => {
+      const normalized = normalizeLabel(label);
+      return messageMap[normalized] ?? label;
+    });
+  }, [labels, monthLabelMessages, slot, weekLabelMessages]);
 
   useEffect(() => {
     fetchData();
@@ -53,7 +126,7 @@ export default function JobNumberBarChart({ slot }: JobNumberDateChartProps) {
           label: intl.formatMessage({ id: 'dashboard.charts.job-number-bar.series-label', defaultMessage: 'Job Numbers' })
         }
       ]}
-      xAxis={[{ data: labels, scaleType: 'band', disableLine: true, disableTicks: true, tickLabelStyle: axisFonstyle }]}
+      xAxis={[{ data: displayLabels, scaleType: 'band', disableLine: true, disableTicks: true, tickLabelStyle: axisFonstyle }]}
       yAxis={[{ position: 'none' }]}
       slotProps={{ bar: { rx: 5, ry: 5 } }}
       axisHighlight={{ x: 'none' }}


### PR DESCRIPTION
## Summary
- translate default product setting titles and option labels using react-intl for both export and import flows
- map default product field keys to localized messages and normalize product_info keys in the shared formatter
- translate GuideAIForm validation, labels, and statuses plus localize weekly/monthly chart labels in JobNumberBarChart

## Testing
- npm run lint *(fails: existing lint errors in unrelated files such as JobNumberPieChart.tsx and legacy form components)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a221fc1c8325a9df8aad748da483